### PR TITLE
Pull ecbuild from GitHub

### DIFF
--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -12,9 +12,6 @@ on:
       eckit:
         required: false
         type: string
-      metkit:
-        required: false
-        type: string
       atlas:
         required: false
         type: string
@@ -36,7 +33,6 @@ jobs:
           ${{ inputs.ecbuild || 'ecmwf/ecbuild@develop' }}
           ${{ inputs.eccodes || 'ecmwf/eccodes@develop' }}
           ${{ inputs.eckit || 'ecmwf/eckit@develop' }}
-          ${{ inputs.metkit || 'ecmwf/metkit@develop' }}
           ${{ inputs.atlas || 'ecmwf/atlas@develop' }}
         --parallel: 64
     secrets: inherit

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -9,9 +9,6 @@ on:
       eckit:
         required: false
         type: string
-      metkit:
-        required: false
-        type: string
       atlas:
         required: false
         type: string
@@ -33,7 +30,6 @@ jobs:
             MathisRosenhauer/libaec@master
             ${{ inputs.eccodes || 'ecmwf/eccodes' }}
             ${{ inputs.eckit || 'ecmwf/eckit' }}
-            ${{ inputs.metkit || 'ecmwf/metkit' }}
             ${{ inputs.atlas || 'ecmwf/atlas' }}
         dependency_branch: develop
         parallelism_factor: 8


### PR DESCRIPTION
Pull ecbuild from GitHub instead of module load for HPC builds because that has the latest version.