### PR TITLE
Disable recursing in tests directory if tests are disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,10 @@ include(cmake/compiler_warnings.cmake) # optionally handle compiler specific war
 add_subdirectory(src)
 add_subdirectory(etc)
 add_subdirectory(share)
-add_subdirectory(tests)
+
+if(mir_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()
 
 
 ecbuild_add_resources(TARGET ${PROJECT_NAME}_top_files SOURCES AUTHORS README NOTICE LICENSE INSTALL COPYING)


### PR DESCRIPTION
The CMakeLists.txt in the tests directory is trying to enable assertions even if the tests are disabled. This is done by trying to set properties of the test target, but since the tests are disabled, the test target is not created so the cmake generation step fails.