### PR TITLE
Switch to public Downstream CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,12 @@ jobs:
           repository: private-downstream-ci
           event_type: downstream-ci-hpc
           payload: '{"mir": "ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}"}'
+
+  codecov:
+    name: code-coverage
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      mir: ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}
+      codecov: true
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
   # Calls a reusable CI workflow to build & test the current repository.
   downstream-ci:
     name: downstream-ci
-    uses: ecmwf-actions/private-downstream-ci/.github/workflows/downstream-ci.yml@main
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
     with:
       mir: ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
 
   downstream-ci-hpc:
     name: downstream-ci-hpc
-    uses: ecmwf-actions/private-downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
     with:
       mir: ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch: ~
 
 jobs:
-  # Calls a reusable CI workflow to build & test the current repository.
+  # Run CI including downstream packages on self-hosted runners
   downstream-ci:
     name: downstream-ci
     uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
@@ -24,9 +24,44 @@ jobs:
       mir: ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
 
+  # Run CI of private downstream packages on self-hosted runners
+  private-downstream-ci:
+    name: private-downstream-ci
+    needs: [downstream-ci]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Dispatch private downstream CI
+        uses: ecmwf-actions/dispatch-private-downstream-ci@v1
+        with:
+          token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          owner: ecmwf-actions
+          repository: private-downstream-ci
+          event_type: downstream-ci
+          payload: '{"mir": "ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}"}'
+
+  # Build downstream packages on HPC
   downstream-ci-hpc:
     name: downstream-ci-hpc
     uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
     with:
       mir: ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
+
+  # Run CI of private downstream packages on HPC
+  private-downstream-ci-hpc:
+    name: private-downstream-ci-hpc
+    needs: [downstream-ci-hpc]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Dispatch private downstream CI
+        uses: ecmwf-actions/dispatch-private-downstream-ci@v1
+        with:
+          token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          owner: ecmwf-actions
+          repository: private-downstream-ci
+          event_type: downstream-ci-hpc
+          payload: '{"mir": "ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,15 @@ on:
   # Trigger the workflow manually
   workflow_dispatch: ~
 
+  # Trigger after public PR approved for CI
+  pull_request_target:
+    types: [labeled]
+
 jobs:
   # Run CI including downstream packages on self-hosted runners
   downstream-ci:
     name: downstream-ci
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
     with:
       mir: ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}
@@ -28,6 +33,7 @@ jobs:
   private-downstream-ci:
     name: private-downstream-ci
     needs: [downstream-ci]
+    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -44,6 +50,7 @@ jobs:
   # Build downstream packages on HPC
   downstream-ci-hpc:
     name: downstream-ci-hpc
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
     with:
       mir: ecmwf/mir@${{ github.event.pull_request.head.sha || github.sha }}
@@ -53,6 +60,7 @@ jobs:
   private-downstream-ci-hpc:
     name: private-downstream-ci-hpc
     needs: [downstream-ci-hpc]
+    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -1,0 +1,10 @@
+# Manage labels of pull requests that originate from forks
+name: label-public-pr
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -15,6 +15,10 @@ on:
       mir:
         required: false
         type: string
+      codecov:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   ci:
@@ -23,8 +27,10 @@ jobs:
     with:
       repository: ${{ inputs.mir || 'ecmwf/mir@develop' }}
       name_prefix: mir-
+      codecov_upload: ${{ inputs.codecov }}
       build_package_inputs: |
         repository: ${{ inputs.mir || 'ecmwf/mir@develop' }}
+        self_coverage: true
         dependencies: |
             ecmwf/ecbuild
             MathisRosenhauer/libaec@master

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -38,5 +38,7 @@ jobs:
             ${{ inputs.eckit || 'ecmwf/eckit' }}
             ${{ inputs.atlas || 'ecmwf/atlas' }}
         dependency_branch: develop
+        dependency_cmake_options: |
+            ${{ inputs.codecov && 'ecmwf/atlas: "-DENABLE_OMP=0"' || '' }}
         parallelism_factor: 8
     secrets: inherit


### PR DESCRIPTION
Since mir is now a public repository, call public downstream CI.
Adds label based approval system for running CI on pull requests opened from forks. Running CI on external PR is approved by labeling the PR with `approved-for-ci` label. This label is not needed for PRs just between branches within this repository.
Adds code coverage report generation.