### PR TITLE
move template up

### DIFF
--- a/src/mir/repres/other/UnstructuredGrid.cc
+++ b/src/mir/repres/other/UnstructuredGrid.cc
@@ -46,6 +46,23 @@
 
 
 namespace mir::repres {
+
+template <>
+Representation* RepresentationBuilder<other::UnstructuredGrid>::make(const param::MIRParametrisation& param) {
+#if mir_HAVE_ATLAS
+    // specially-named unstructured grids
+    std::string grid;
+    if (param.get("grid", grid)) {
+        if (!key::grid::ORCAPattern::match(grid, param).empty()) {
+            return new other::ORCA(param);
+        }
+    }
+#endif
+
+    return new other::UnstructuredGrid(param);
+}
+
+
 namespace other {
 
 
@@ -275,21 +292,6 @@ static const RepresentationBuilder<UnstructuredGrid> unstructured_grid("unstruct
 
 }  // namespace other
 
-
-template <>
-Representation* RepresentationBuilder<other::UnstructuredGrid>::make(const param::MIRParametrisation& param) {
-#if mir_HAVE_ATLAS
-    // specially-named unstructured grids
-    std::string grid;
-    if (param.get("grid", grid)) {
-        if (!key::grid::ORCAPattern::match(grid, param).empty()) {
-            return new other::ORCA(param);
-        }
-    }
-#endif
-
-    return new other::UnstructuredGrid(param);
-}
 
 
 }  // namespace mir::repres


### PR DESCRIPTION
This part failed to compile on LUMI, with Cray compiler ("used before defined"), so the relevant part was moved up