### PR TITLE
Fix compilation with Cray compiler cce/15.0.1

### DIFF
--- a/src/mir/repres/other/UnstructuredGrid.cc
+++ b/src/mir/repres/other/UnstructuredGrid.cc
@@ -46,6 +46,23 @@
 
 
 namespace mir::repres {
+
+template <>
+Representation* RepresentationBuilder<other::UnstructuredGrid>::make(const param::MIRParametrisation& param) {
+#if mir_HAVE_ATLAS
+    // specially-named unstructured grids
+    std::string grid;
+    if (param.get("grid", grid)) {
+        if (!key::grid::ORCAPattern::match(grid, param).empty()) {
+            return new other::ORCA(param);
+        }
+    }
+#endif
+
+    return new other::UnstructuredGrid(param);
+}
+
+
 namespace other {
 
 
@@ -275,21 +292,6 @@ static const RepresentationBuilder<UnstructuredGrid> unstructured_grid("unstruct
 
 }  // namespace other
 
-
-template <>
-Representation* RepresentationBuilder<other::UnstructuredGrid>::make(const param::MIRParametrisation& param) {
-#if mir_HAVE_ATLAS
-    // specially-named unstructured grids
-    std::string grid;
-    if (param.get("grid", grid)) {
-        if (!key::grid::ORCAPattern::match(grid, param).empty()) {
-            return new other::ORCA(param);
-        }
-    }
-#endif
-
-    return new other::UnstructuredGrid(param);
-}
 
 
 }  // namespace mir::repres


### PR DESCRIPTION
This PR fixes following error:
```
ifs-bundle/source/mir/src/mir/repres/other/UnstructuredGrid.cc:280:65: error: explicit specialization of 'make' after instantiation
Representation* RepresentationBuilder<other::UnstructuredGrid>::make(const param::MIRParametrisation& param) {
                                                                ^
ifs-bundle/source/mir/src/mir/repres/other/UnstructuredGrid.cc:272:54: note: implicit instantiation first required here
static const RepresentationBuilder<UnstructuredGrid> triangular_grid("triangular_grid");
                                                     ^
```
This happens on [LUMI](https://lumi-supercomputer.eu) with environment:
```
module load LUMI/23.03
module load partition/G
module load cpeCray/23.03
module load cray-mpich/8.1.25
module load Eigen/3.4
module load libaec/1.0.6-cpeCray-23.03
module load Boost/1.81.0-cpeCray-23.03
module load ncurses/6.4-cpeCray-23.03
module load buildtools/23.03
module load cray-python/3.9.13.1 ECBUNDLE_CONFIGURE_ONLY
module load craype-network-ofi
module load craype-accel-amd-gfx90a
module load rocm/5.2.3
module load cray-dsmml/0.2.2
export CC=cc
export CXX=CC
export FC=ftn
```