### PR TITLE
Feature/earthkit regrid interpolationspec

### DIFF
--- a/src/mir/CMakeLists.txt
+++ b/src/mir/CMakeLists.txt
@@ -426,8 +426,8 @@ list(APPEND mir_srcs
     method/nonlinear/NoNonLinear.h
     method/nonlinear/NonLinear.cc
     method/nonlinear/NonLinear.h
-    method/nonlinear/SimulateMissingValue.cc
-    method/nonlinear/SimulateMissingValue.h
+    method/nonlinear/SimulatedMissingValue.cc
+    method/nonlinear/SimulatedMissingValue.h
     method/solver/Multiply.cc
     method/solver/Multiply.h
     method/solver/Solver.h

--- a/src/mir/method/Method.h
+++ b/src/mir/method/Method.h
@@ -42,11 +42,14 @@ namespace mir::method {
 class Method {
 public:
     Method(const param::MIRParametrisation&);
+
     Method(const Method&) = delete;
+    Method(Method&&)      = delete;
 
     virtual ~Method();
 
     void operator=(const Method&) = delete;
+    void operator=(Method&&)      = delete;
 
     virtual void hash(eckit::MD5&) const = 0;
 

--- a/src/mir/method/MethodWeighted.cc
+++ b/src/mir/method/MethodWeighted.cc
@@ -79,6 +79,22 @@ MethodWeighted::MethodWeighted(const param::MIRParametrisation& parametrisation)
 MethodWeighted::~MethodWeighted() = default;
 
 
+void MethodWeighted::json(eckit::JSON& j) const {
+    j << "nonLinear";
+    j.startList();
+    for (const auto& n : nonLinear_) {
+        j << *n;
+    }
+    j.endList();
+
+    j << "solver" << *solver_;
+    j << "cropping" << cropping_;
+    j << "lsmWeightAdjustment" << lsmWeightAdjustment_;
+    j << "pruneEpsilon" << pruneEpsilon_;
+    j << "poleDisplacement" << poleDisplacement_;
+}
+
+
 void MethodWeighted::print(std::ostream& out) const {
     out << "nonLinear[";
     const auto* sep = "";
@@ -238,9 +254,16 @@ const WeightMatrix& MethodWeighted::getMatrix(context::Context& ctx, const repre
         j.startObject();
         j << "input" << in;
         j << "output" << out;
+        j << "interpolation" << *this;
+
+        j << "matrix";
+        j.startObject();
         j << "rows" << w.rows();
         j << "columns" << w.cols();
+        j << "nnz" << w.nonZeros();
         j << "cache_file" << cacheFile;
+        j.endObject();
+
         j.endObject();
     }
 

--- a/src/mir/method/MethodWeighted.h
+++ b/src/mir/method/MethodWeighted.h
@@ -20,6 +20,10 @@
 #include "mir/method/WeightMatrix.h"
 
 
+namespace eckit {
+class JSON;
+}
+
 namespace mir {
 namespace data {
 class Space;
@@ -95,7 +99,8 @@ protected:
 
     // -- Methods
 
-    virtual const char* name() const = 0;
+    virtual void json(eckit::JSON&) const = 0;
+    virtual const char* name() const      = 0;
     const solver::Solver& solver() const;
     void addNonLinearTreatment(const nonlinear::NonLinear*);
     void setSolver(const solver::Solver*);
@@ -165,7 +170,13 @@ private:
     // None
 
     // -- Friends
+
     friend class MatrixCacheCreator;
+
+    friend eckit::JSON& operator<<(eckit::JSON& s, const MethodWeighted& o) {
+        o.json(s);
+        return s;
+    }
 };
 
 

--- a/src/mir/method/fe/FEBilinear.h
+++ b/src/mir/method/fe/FEBilinear.h
@@ -18,75 +18,11 @@
 namespace mir::method::fe {
 
 
-class FEBilinear : public FiniteElement {
-public:
-    // -- Types
-    // None
-
-    // -- Exceptions
-    // None
-
-    // -- Constructors
-
-    FEBilinear(const param::MIRParametrisation&, const std::string& label = "input");
-
-    // -- Destructor
-    // None
-
-    // -- Convertors
-    // None
-
-    // -- Operators
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-protected:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
+struct FEBilinear final : FiniteElement {
+    explicit FEBilinear(const param::MIRParametrisation&, const std::string& label = "input");
 
 private:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-
-    // From MethodWeighted
     const char* name() const override;
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-    // -- Friends
-    // None
 };
 
 

--- a/src/mir/method/fe/FELinear.h
+++ b/src/mir/method/fe/FELinear.h
@@ -18,75 +18,11 @@
 namespace mir::method::fe {
 
 
-class FELinear : public FiniteElement {
-public:
-    // -- Types
-    // None
-
-    // -- Exceptions
-    // None
-
-    // -- Constructors
-
-    FELinear(const param::MIRParametrisation&, const std::string& label = "input");
-
-    // -- Destructor
-    // None
-
-    // -- Convertors
-    // None
-
-    // -- Operators
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-protected:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
+struct FELinear final : FiniteElement {
+    explicit FELinear(const param::MIRParametrisation&, const std::string& label = "input");
 
 private:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-
-    // From MethodWeighted
     const char* name() const override;
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-    // -- Friends
-    // None
 };
 
 

--- a/src/mir/method/fe/FiniteElement.cc
+++ b/src/mir/method/fe/FiniteElement.cc
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <utility>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 #include "eckit/utils/StringTools.h"
 
@@ -241,6 +242,20 @@ bool FiniteElement::sameAs(const Method& other) const {
     const auto* o = dynamic_cast<const FiniteElement*>(&other);
     return (o != nullptr) && meshGeneratorParams_.sameAs(o->meshGeneratorParams_) &&
            validateMesh_ == o->validateMesh_ && projectionFail_ == o->projectionFail_ && MethodWeighted::sameAs(other);
+}
+
+
+void FiniteElement::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "name" << name();
+    MethodWeighted::json(j);
+    j << "validateMesh" << validateMesh_;
+    j << "projectionFail"
+      << (projectionFail_ == ProjectionFail::failure           ? "fail"
+          : projectionFail_ == ProjectionFail::increaseEpsilon ? "increase-epsilon"
+          : projectionFail_ == ProjectionFail::missingValue    ? "missing-value"
+                                                               : NOTIMP);
+    j.endObject();
 }
 
 

--- a/src/mir/method/fe/FiniteElement.h
+++ b/src/mir/method/fe/FiniteElement.h
@@ -102,6 +102,7 @@ private:
     void assemble(util::MIRStatistics&, WeightMatrix&, const repres::Representation& in,
                   const repres::Representation& out) const override;
     bool sameAs(const Method&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
 
     // -- Overridden methods

--- a/src/mir/method/fe/L2Projection.cc
+++ b/src/mir/method/fe/L2Projection.cc
@@ -14,6 +14,7 @@
 
 #include "eckit/linalg/LinearAlgebraSparse.h"
 #include "eckit/linalg/Vector.h"
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -45,13 +46,19 @@ L2Projection::L2Projection(const param::MIRParametrisation& param) : MethodWeigh
 }
 
 
-L2Projection::~L2Projection() = default;
-
-
 bool L2Projection::sameAs(const Method& other) const {
     const auto* o = dynamic_cast<const L2Projection*>(&other);
     return (o != nullptr) && inputMethod_->sameAs(*(o->inputMethod_)) && outputMethod_->sameAs(*(o->outputMethod_)) &&
            MethodWeighted::sameAs(*o);
+}
+
+
+void L2Projection::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "l2-projection";
+    j << "input", *inputMethod_;
+    j << "output", *outputMethod_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/fe/L2Projection.h
+++ b/src/mir/method/fe/L2Projection.h
@@ -29,86 +29,22 @@ namespace mir::method::fe {
  * @brief The L2 Projection interpolation method
  * See <https://earthsystemcog.org/doc/detail/2201/>
  */
-class L2Projection : public MethodWeighted {
-public:
-    // -- Types
-    // None
-
-    // -- Exceptions
-    // None
-
-    // -- Constructors
-
-    L2Projection(const param::MIRParametrisation&);
-
-    // -- Destructor
-
-    ~L2Projection() override;
-
-    // -- Convertors
-    // None
-
-    // -- Operators
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-protected:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
+struct L2Projection final : MethodWeighted {
+    explicit L2Projection(const param::MIRParametrisation&);
 
 private:
-    // -- Members
-
-    std::unique_ptr<FiniteElement> inputMethod_;
-    std::unique_ptr<FiniteElement> outputMethod_;
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-
-    // From Method
     void hash(eckit::MD5&) const override;
     int version() const override;
     bool sameAs(const Method&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
 
-    // From MethodWeighted
     void assemble(util::MIRStatistics&, WeightMatrix&, const repres::Representation& in,
                   const repres::Representation& out) const override;
     const char* name() const override;
 
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-    // -- Friends
-    // None
+    std::unique_ptr<FiniteElement> inputMethod_;
+    std::unique_ptr<FiniteElement> outputMethod_;
 };
 
 

--- a/src/mir/method/gridbox/GridBoxAverage.h
+++ b/src/mir/method/gridbox/GridBoxAverage.h
@@ -18,73 +18,8 @@
 namespace mir::method::gridbox {
 
 
-class GridBoxAverage : public GridBoxMethod {
-public:
-    // -- Types
-    // None
-
-    // -- Exceptions
-    // None
-
-    // -- Constructors
-
+struct GridBoxAverage final : GridBoxMethod {
     using GridBoxMethod::GridBoxMethod;
-
-    // -- Destructor
-    // None
-
-    // -- Convertors
-    // None
-
-    // -- Operators
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-protected:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-private:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-    // -- Friends
-    // None
 };
 
 

--- a/src/mir/method/gridbox/GridBoxMethod.h
+++ b/src/mir/method/gridbox/GridBoxMethod.h
@@ -20,81 +20,18 @@ namespace mir::method::gridbox {
 
 class GridBoxMethod : public MethodWeighted {
 public:
-    // -- Types
-    // None
-
-    // -- Exceptions
-    // None
-
-    // -- Constructors
-
-    GridBoxMethod(const param::MIRParametrisation&);
-
-    // -- Destructor
-
-    ~GridBoxMethod() override;
-
-    // -- Convertors
-    // None
-
-    // -- Operators
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-protected:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
+    explicit GridBoxMethod(const param::MIRParametrisation&);
 
 private:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-
-    // From MethodWeighted
     void hash(eckit::MD5&) const override;
     void assemble(util::MIRStatistics&, WeightMatrix&, const repres::Representation& in,
                   const repres::Representation& out) const override;
     bool sameAs(const Method&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     bool validateMatrixWeights() const override;
     const char* name() const override;
     int version() const override;
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-    // -- Friends
-    // None
 };
 
 

--- a/src/mir/method/gridbox/GridBoxStatistics.h
+++ b/src/mir/method/gridbox/GridBoxStatistics.h
@@ -20,8 +20,6 @@ namespace mir::method::gridbox {
 
 struct GridBoxStatistics final : GridBoxMethod {
     explicit GridBoxStatistics(const param::MIRParametrisation&);
-    GridBoxStatistics(const GridBoxStatistics&) = delete;
-    void operator=(const GridBoxStatistics&)    = delete;
 };
 
 

--- a/src/mir/method/knn/KNearest.cc
+++ b/src/mir/method/knn/KNearest.cc
@@ -35,9 +35,6 @@ KNearest::KNearest(const param::MIRParametrisation& param) : KNearestNeighbours(
 }
 
 
-KNearest::~KNearest() = default;
-
-
 bool KNearest::sameAs(const Method& other) const {
     const auto* o = dynamic_cast<const KNearest*>(&other);
     return (o != nullptr) && KNearestNeighbours::sameAs(other);

--- a/src/mir/method/knn/KNearest.h
+++ b/src/mir/method/knn/KNearest.h
@@ -20,11 +20,8 @@
 namespace mir::method::knn {
 
 
-class KNearest : public KNearestNeighbours {
-public:
-    KNearest(const param::MIRParametrisation&);
-
-    ~KNearest() override;
+struct KNearest final : KNearestNeighbours {
+    explicit KNearest(const param::MIRParametrisation&);
 
 private:
     const char* name() const override;

--- a/src/mir/method/knn/KNearestNeighbours.cc
+++ b/src/mir/method/knn/KNearestNeighbours.cc
@@ -144,6 +144,16 @@ void KNearestNeighbours::assemble(util::MIRStatistics& /*unused*/, WeightMatrix&
 }
 
 
+void KNearestNeighbours::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << name();
+    MethodWeighted::json(j);
+    j << "nearestMethod" << pick();
+    j << "distanceWeighting" << distanceWeighting();
+    j.endObject();
+}
+
+
 void KNearestNeighbours::print(std::ostream& out) const {
     out << "KNearestNeighbours[";
     MethodWeighted::print(out);

--- a/src/mir/method/knn/KNearestNeighbours.h
+++ b/src/mir/method/knn/KNearestNeighbours.h
@@ -48,6 +48,7 @@ protected:
     bool sameAs(const Method&) const override = 0;
 
 private:
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
 
     const char* name() const override = 0;

--- a/src/mir/method/knn/KNearestStatistics.cc
+++ b/src/mir/method/knn/KNearestStatistics.cc
@@ -41,9 +41,6 @@ const char* KNearestStatistics::name() const {
 }
 
 
-KNearestStatistics::~KNearestStatistics() = default;
-
-
 bool KNearestStatistics::sameAs(const Method& other) const {
     const auto* o = dynamic_cast<const KNearestStatistics*>(&other);
     return (o != nullptr) && KNearestStatistics::sameAs(other);

--- a/src/mir/method/knn/KNearestStatistics.h
+++ b/src/mir/method/knn/KNearestStatistics.h
@@ -21,11 +21,8 @@
 namespace mir::method::knn {
 
 
-class KNearestStatistics : public KNearestNeighbours {
-public:
-    KNearestStatistics(const param::MIRParametrisation&);
-
-    ~KNearestStatistics() override;
+struct KNearestStatistics final : KNearestNeighbours {
+    explicit KNearestStatistics(const param::MIRParametrisation&);
 
 private:
     const char* name() const override;

--- a/src/mir/method/knn/NearestLSM.cc
+++ b/src/mir/method/knn/NearestLSM.cc
@@ -30,9 +30,6 @@ NearestLSM::NearestLSM(const param::MIRParametrisation& param) : KNearestNeighbo
 }
 
 
-NearestLSM::~NearestLSM() = default;
-
-
 void NearestLSM::assemble(util::MIRStatistics& stats, WeightMatrix& W, const repres::Representation& in,
                           const repres::Representation& out) const {
 

--- a/src/mir/method/knn/NearestLSM.h
+++ b/src/mir/method/knn/NearestLSM.h
@@ -20,11 +20,8 @@
 namespace mir::method::knn {
 
 
-class NearestLSM : public KNearestNeighbours {
-public:
-    NearestLSM(const param::MIRParametrisation&);
-
-    ~NearestLSM() override;
+struct NearestLSM final : KNearestNeighbours {
+    explicit NearestLSM(const param::MIRParametrisation&);
 
 private:
     void assemble(util::MIRStatistics&, WeightMatrix&, const repres::Representation& in,

--- a/src/mir/method/knn/NearestNeighbour.cc
+++ b/src/mir/method/knn/NearestNeighbour.cc
@@ -29,9 +29,6 @@ NearestNeighbour::NearestNeighbour(const param::MIRParametrisation& param) :
 }
 
 
-NearestNeighbour::~NearestNeighbour() = default;
-
-
 bool NearestNeighbour::sameAs(const Method& other) const {
     const auto* o = dynamic_cast<const NearestNeighbour*>(&other);
     return (o != nullptr) && KNearestNeighbours::sameAs(other);

--- a/src/mir/method/knn/NearestNeighbour.h
+++ b/src/mir/method/knn/NearestNeighbour.h
@@ -20,11 +20,8 @@
 namespace mir::method::knn {
 
 
-class NearestNeighbour : public KNearestNeighbours {
-public:
-    NearestNeighbour(const param::MIRParametrisation&);
-
-    ~NearestNeighbour() override;
+struct NearestNeighbour final : KNearestNeighbours {
+    explicit NearestNeighbour(const param::MIRParametrisation&);
 
 private:
     const char* name() const override;

--- a/src/mir/method/knn/distance/ClimateFilter.cc
+++ b/src/mir/method/knn/distance/ClimateFilter.cc
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <string>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -88,6 +89,14 @@ bool ClimateFilter::sameAs(const DistanceWeighting& other) const {
     const auto* o = dynamic_cast<const ClimateFilter*>(&other);
     return (o != nullptr) && eckit::types::is_approximately_equal(halfDelta_, o->halfDelta_) &&
            eckit::types::is_approximately_equal(delta_, o->delta_);
+}
+
+
+void ClimateFilter::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "climate-filter";
+    j << "climate-filter-delta" << delta_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/ClimateFilter.h
+++ b/src/mir/method/knn/distance/ClimateFilter.h
@@ -25,8 +25,10 @@ struct ClimateFilter : DistanceWeighting {
 
 private:
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
     double halfDelta_;
     double delta_;
 };

--- a/src/mir/method/knn/distance/Cressman.cc
+++ b/src/mir/method/knn/distance/Cressman.cc
@@ -14,6 +14,7 @@
 
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -66,6 +67,13 @@ void Cressman::operator()(size_t ip, const Point3& point,
 bool Cressman::sameAs(const DistanceWeighting& other) const {
     const auto* o = dynamic_cast<const Cressman*>(&other);
     return (o != nullptr) && eckit::types::is_approximately_equal(r_, o->r_);
+}
+
+
+void Cressman::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "cressman";
+    j.endList();
 }
 
 

--- a/src/mir/method/knn/distance/Cressman.h
+++ b/src/mir/method/knn/distance/Cressman.h
@@ -22,18 +22,20 @@ namespace mir::method::knn::distance {
  * Cressman, George P., An operational objective analysis system. Mon. Wea. Rev., 87, 367-374 (01 Oct 1959),
  * @ref http://dx.doi.org/10.1175/1520-0493(1959)087<0367:AOOAS>2.0.CO;2
  */
-struct Cressman : DistanceWeighting {
-    Cressman(const param::MIRParametrisation&);
+struct Cressman final : DistanceWeighting {
+    explicit Cressman(const param::MIRParametrisation&);
     void operator()(size_t ip, const Point3& point, const std::vector<search::PointSearch::PointValueType>& neighbours,
                     std::vector<WeightMatrix::Triplet>& triplets) const override;
 
 private:
+    bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
+    void print(std::ostream&) const override;
+    void hash(eckit::MD5&) const override;
+
     double r_;
     double r2_;
     double power_;
-    bool sameAs(const DistanceWeighting&) const override;
-    void print(std::ostream&) const override;
-    void hash(eckit::MD5&) const override;
 };
 
 

--- a/src/mir/method/knn/distance/DistanceWeighting.h
+++ b/src/mir/method/knn/distance/DistanceWeighting.h
@@ -19,8 +19,9 @@
 
 
 namespace eckit {
+class JSON;
 class MD5;
-}
+}  // namespace eckit
 
 
 namespace mir::method::knn::distance {
@@ -29,6 +30,12 @@ namespace mir::method::knn::distance {
 class DistanceWeighting {
 public:
     DistanceWeighting();
+
+    DistanceWeighting(const DistanceWeighting&) = delete;
+    DistanceWeighting(DistanceWeighting&&)      = delete;
+
+    DistanceWeighting& operator=(const DistanceWeighting&) = delete;
+    DistanceWeighting& operator=(DistanceWeighting&&)      = delete;
 
     virtual ~DistanceWeighting();
 
@@ -41,13 +48,16 @@ public:
     virtual void hash(eckit::MD5&) const = 0;
 
 private:
-    DistanceWeighting(const DistanceWeighting&)            = delete;
-    DistanceWeighting& operator=(const DistanceWeighting&) = delete;
-
+    virtual void json(eckit::JSON&) const   = 0;
     virtual void print(std::ostream&) const = 0;
 
     friend std::ostream& operator<<(std::ostream& s, const DistanceWeighting& p) {
         p.print(s);
+        return s;
+    }
+
+    friend eckit::JSON& operator<<(eckit::JSON& s, const DistanceWeighting& p) {
+        p.json(s);
         return s;
     }
 };
@@ -58,14 +68,17 @@ private:
     std::string name_;
     virtual DistanceWeighting* make(const param::MIRParametrisation&) = 0;
 
-    DistanceWeightingFactory(const DistanceWeightingFactory&)            = delete;
-    DistanceWeightingFactory& operator=(const DistanceWeightingFactory&) = delete;
-
 protected:
-    DistanceWeightingFactory(const std::string& name);
+    explicit DistanceWeightingFactory(const std::string& name);
     virtual ~DistanceWeightingFactory();
 
 public:
+    DistanceWeightingFactory(const DistanceWeightingFactory&) = delete;
+    DistanceWeightingFactory(DistanceWeightingFactory&&)      = delete;
+
+    DistanceWeightingFactory& operator=(const DistanceWeightingFactory&) = delete;
+    DistanceWeightingFactory& operator=(DistanceWeightingFactory&&)      = delete;
+
     static const DistanceWeighting* build(const std::string& name, const param::MIRParametrisation&);
     static void list(std::ostream&);
 };
@@ -76,7 +89,7 @@ class DistanceWeightingBuilder : public DistanceWeightingFactory {
     DistanceWeighting* make(const param::MIRParametrisation& param) override { return new T(param); }
 
 public:
-    DistanceWeightingBuilder(const std::string& name) : DistanceWeightingFactory(name) {}
+    explicit DistanceWeightingBuilder(const std::string& name) : DistanceWeightingFactory(name) {}
 };
 
 

--- a/src/mir/method/knn/distance/DistanceWeightingWithLSM.cc
+++ b/src/mir/method/knn/distance/DistanceWeightingWithLSM.cc
@@ -15,6 +15,7 @@
 #include <map>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 #include "mir/param/MIRParametrisation.h"
@@ -59,6 +60,14 @@ bool DistanceWeightingWithLSM::sameAs(const DistanceWeighting& other) const {
 
     // Note: LSM's themselves are not used for this distinction!
     return (o != nullptr) && method_ == o->method_;
+}
+
+
+void DistanceWeightingWithLSM::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "distance-weighting-with-lsm";
+    j << "distance-weighting-with-lsm" << method_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/DistanceWeightingWithLSM.h
+++ b/src/mir/method/knn/distance/DistanceWeightingWithLSM.h
@@ -25,9 +25,9 @@ class LandSeaMasks;
 namespace mir::method::knn::distance {
 
 
-struct DistanceWeightingWithLSM : DistanceWeighting {
-
-    DistanceWeightingWithLSM(const param::MIRParametrisation&);
+class DistanceWeightingWithLSM : public DistanceWeighting {
+public:
+    explicit DistanceWeightingWithLSM(const param::MIRParametrisation&);
 
     void operator()(size_t, const Point3&, const std::vector<search::PointSearch::PointValueType>&,
                     std::vector<WeightMatrix::Triplet>&) const override {
@@ -37,10 +37,12 @@ struct DistanceWeightingWithLSM : DistanceWeighting {
     const DistanceWeighting* distanceWeighting(const param::MIRParametrisation&, const lsm::LandSeaMasks& lsm) const;
 
 private:
-    std::string method_;
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
+    std::string method_;
 };
 
 
@@ -49,14 +51,17 @@ private:
     std::string name_;
     virtual DistanceWeighting* make(const param::MIRParametrisation&, const lsm::LandSeaMasks&) = 0;
 
-    DistanceWeightingWithLSMFactory(const DistanceWeightingWithLSMFactory&)            = delete;
-    DistanceWeightingWithLSMFactory& operator=(const DistanceWeightingWithLSMFactory&) = delete;
-
 protected:
-    DistanceWeightingWithLSMFactory(const std::string& name);
+    explicit DistanceWeightingWithLSMFactory(const std::string& name);
     virtual ~DistanceWeightingWithLSMFactory();
 
 public:
+    DistanceWeightingWithLSMFactory(const DistanceWeightingWithLSMFactory&) = delete;
+    DistanceWeightingWithLSMFactory(DistanceWeightingWithLSMFactory&&)      = delete;
+
+    DistanceWeightingWithLSMFactory& operator=(const DistanceWeightingWithLSMFactory&) = delete;
+    DistanceWeightingWithLSMFactory& operator=(DistanceWeightingWithLSMFactory&&)      = delete;
+
     static const DistanceWeighting* build(const std::string& name, const param::MIRParametrisation&,
                                           const lsm::LandSeaMasks&);
     static void list(std::ostream&);
@@ -71,7 +76,7 @@ class DistanceWeightingWithLSMBuilder : public DistanceWeightingWithLSMFactory {
     }
 
 public:
-    DistanceWeightingWithLSMBuilder(const std::string& name) : DistanceWeightingWithLSMFactory(name) {}
+    explicit DistanceWeightingWithLSMBuilder(const std::string& name) : DistanceWeightingWithLSMFactory(name) {}
 };
 
 

--- a/src/mir/method/knn/distance/GaussianDistanceWeighting.cc
+++ b/src/mir/method/knn/distance/GaussianDistanceWeighting.cc
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -54,7 +55,7 @@ void GaussianDistanceWeighting::operator()(size_t ip, const Point3& point,
         const double d2     = Point3::distance2(point, n.point());
         const double weight = std::exp(d2 * exponentFactor_);
 
-        triplets.emplace_back(WeightMatrix::Triplet(ip, n.payload(), weight));
+        triplets.emplace_back(ip, n.payload(), weight);
         sum += weight;
     }
 
@@ -69,6 +70,14 @@ void GaussianDistanceWeighting::operator()(size_t ip, const Point3& point,
 bool GaussianDistanceWeighting::sameAs(const DistanceWeighting& other) const {
     const auto* o = dynamic_cast<const GaussianDistanceWeighting*>(&other);
     return (o != nullptr) && eckit::types::is_approximately_equal(stddev_, o->stddev_);
+}
+
+
+void GaussianDistanceWeighting::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "gaussian";
+    j << "distance-weighting-gaussian-stddev" << stddev_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/GaussianDistanceWeighting.h
+++ b/src/mir/method/knn/distance/GaussianDistanceWeighting.h
@@ -24,11 +24,13 @@ struct GaussianDistanceWeighting : DistanceWeighting {
                     std::vector<WeightMatrix::Triplet>& triplets) const override;
 
 private:
-    double stddev_;
-    double exponentFactor_;
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
+    double stddev_;
+    double exponentFactor_;
 };
 
 

--- a/src/mir/method/knn/distance/InverseDistanceWeighting.cc
+++ b/src/mir/method/knn/distance/InverseDistanceWeighting.cc
@@ -14,6 +14,7 @@
 
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -57,7 +58,7 @@ void InverseDistanceWeighting::operator()(size_t ip, const Point3& point,
         const double d2 = Point3::distance2(point, neighbours[j].point());
         if (eckit::types::is_approximately_equal(d2, 0.)) {
             // exact match found, use this neighbour only (inverse distance tends to infinity)
-            triplets.assign(1, WeightMatrix::Triplet(ip, neighbours[j].payload(), 1.));
+            triplets.assign(1, {ip, neighbours[j].payload(), 1.});
             return;
         }
 
@@ -70,7 +71,7 @@ void InverseDistanceWeighting::operator()(size_t ip, const Point3& point,
     // normalise all weights according to the total, and set sparse matrix triplets
     for (size_t j = 0; j < nbPoints; ++j) {
         size_t jp = neighbours[j].payload();
-        triplets.emplace_back(WeightMatrix::Triplet(ip, jp, weights[j] / sum));
+        triplets.emplace_back(ip, jp, weights[j] / sum);
     }
 }
 
@@ -78,6 +79,14 @@ void InverseDistanceWeighting::operator()(size_t ip, const Point3& point,
 bool InverseDistanceWeighting::sameAs(const DistanceWeighting& other) const {
     const auto* o = dynamic_cast<const InverseDistanceWeighting*>(&other);
     return (o != nullptr) && eckit::types::is_approximately_equal(power_, o->power_);
+}
+
+
+void InverseDistanceWeighting::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "inverse-distance-weighting";
+    j << "inverse-distance-weighting-power" << power_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/InverseDistanceWeighting.h
+++ b/src/mir/method/knn/distance/InverseDistanceWeighting.h
@@ -25,11 +25,13 @@ protected:
                     std::vector<WeightMatrix::Triplet>& triplets) const override;
 
 private:
-    double power_;
-    double halfPower_;
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON& j) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
+    double power_;
+    double halfPower_;
 };
 
 

--- a/src/mir/method/knn/distance/InverseDistanceWeightingSquared.cc
+++ b/src/mir/method/knn/distance/InverseDistanceWeightingSquared.cc
@@ -14,6 +14,7 @@
 
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 #include "mir/util/Exceptions.h"
@@ -50,7 +51,7 @@ void InverseDistanceWeightingSquared::operator()(size_t ip, const Point3& point,
     // normalise all weights according to the total, and set sparse matrix triplets
     for (size_t i = 0; i < nbPoints; ++i) {
         size_t jp = neighbours[i].payload();
-        triplets.emplace_back(WeightMatrix::Triplet(ip, jp, weights[i] / sum));
+        triplets.emplace_back(ip, jp, weights[i] / sum);
     }
 }
 
@@ -58,6 +59,13 @@ void InverseDistanceWeightingSquared::operator()(size_t ip, const Point3& point,
 bool InverseDistanceWeightingSquared::sameAs(const DistanceWeighting& other) const {
     const auto* o = dynamic_cast<const InverseDistanceWeightingSquared*>(&other);
     return (o != nullptr);
+}
+
+
+void InverseDistanceWeightingSquared::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "inverse-distance-weighting-squared";
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/InverseDistanceWeightingSquared.h
+++ b/src/mir/method/knn/distance/InverseDistanceWeightingSquared.h
@@ -25,6 +25,7 @@ struct InverseDistanceWeightingSquared : DistanceWeighting {
 
 private:
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 };

--- a/src/mir/method/knn/distance/NearestLSM.cc
+++ b/src/mir/method/knn/distance/NearestLSM.cc
@@ -14,6 +14,7 @@
 
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 #include "mir/lsm/LandSeaMasks.h"
@@ -56,13 +57,20 @@ void NearestLSM::operator()(size_t ip, const Point3& /*unused*/,
         jp = neighbours.front().payload();
     }
 
-    triplets.assign(1, WeightMatrix::Triplet(ip, jp, 1.));
+    triplets.assign(1, {ip, jp, 1.});
 }
 
 
 bool NearestLSM::sameAs(const DistanceWeighting& other) const {
     const auto* o = dynamic_cast<const NearestLSM*>(&other);
     return (o != nullptr);
+}
+
+
+void NearestLSM::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "nearest-lsm";
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/NearestLSM.h
+++ b/src/mir/method/knn/distance/NearestLSM.h
@@ -31,11 +31,13 @@ struct NearestLSM : DistanceWeightingWithLSM {
                     std::vector<WeightMatrix::Triplet>& triplets) const override;
 
 private:
-    const std::vector<bool>& imask_;
-    const std::vector<bool>& omask_;
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
+    const std::vector<bool>& imask_;
+    const std::vector<bool>& omask_;
 };
 
 

--- a/src/mir/method/knn/distance/NearestLSMWithLowestIndex.cc
+++ b/src/mir/method/knn/distance/NearestLSMWithLowestIndex.cc
@@ -15,6 +15,7 @@
 #include <limits>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -74,13 +75,20 @@ void NearestLSMWithLowestIndex::operator()(size_t ip, const Point3& point,
     ASSERT(choice.index() < imask_.size());
     size_t jp = choice.index();
 
-    triplets.assign(1, WeightMatrix::Triplet(ip, jp, 1.));
+    triplets.assign(1, {ip, jp, 1.});
 }
 
 
 bool NearestLSMWithLowestIndex::sameAs(const DistanceWeighting& other) const {
     const auto* o = dynamic_cast<const NearestLSMWithLowestIndex*>(&other);
     return (o != nullptr);
+}
+
+
+void NearestLSMWithLowestIndex::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "nearest-lsm-with-lowest-index";
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/NearestLSMWithLowestIndex.h
+++ b/src/mir/method/knn/distance/NearestLSMWithLowestIndex.h
@@ -31,11 +31,13 @@ struct NearestLSMWithLowestIndex : DistanceWeightingWithLSM {
                     std::vector<WeightMatrix::Triplet>& triplets) const override;
 
 private:
-    const std::vector<bool>& imask_;
-    const std::vector<bool>& omask_;
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
+    const std::vector<bool>& imask_;
+    const std::vector<bool>& omask_;
 };
 
 

--- a/src/mir/method/knn/distance/NearestNeighbour.cc
+++ b/src/mir/method/knn/distance/NearestNeighbour.cc
@@ -14,6 +14,7 @@
 
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 #include "mir/util/Exceptions.h"
@@ -30,13 +31,20 @@ void NearestNeighbour::operator()(size_t ip, const Point3& /*point*/,
                                   std::vector<WeightMatrix::Triplet>& triplets) const {
 
     ASSERT(!neighbours.empty());
-    triplets.assign(1, WeightMatrix::Triplet(ip, neighbours.front().payload(), 1.));
+    triplets.assign(1, {ip, neighbours.front().payload(), 1.});
 }
 
 
 bool NearestNeighbour::sameAs(const DistanceWeighting& other) const {
     const auto* o = dynamic_cast<const NearestNeighbour*>(&other);
     return (o != nullptr);
+}
+
+
+void NearestNeighbour::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "nearest-neighbour";
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/NearestNeighbour.h
+++ b/src/mir/method/knn/distance/NearestNeighbour.h
@@ -25,6 +25,7 @@ struct NearestNeighbour : DistanceWeighting {
 
 private:
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 };

--- a/src/mir/method/knn/distance/NoDistanceWeighting.cc
+++ b/src/mir/method/knn/distance/NoDistanceWeighting.cc
@@ -14,6 +14,7 @@
 
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 #include "mir/util/Exceptions.h"
@@ -34,9 +35,9 @@ void NoDistanceWeighting::operator()(size_t ip, const Point3& /*point*/,
     triplets.reserve(neighbours.size());
 
     // average neighbour points
-    auto weight = 1. / double(neighbours.size());
+    auto weight = 1. / static_cast<double>(neighbours.size());
     for (const auto& n : neighbours) {
-        triplets.emplace_back(WeightMatrix::Triplet(ip, n.payload(), weight));
+        triplets.emplace_back(ip, n.payload(), weight);
     }
 }
 
@@ -44,6 +45,13 @@ void NoDistanceWeighting::operator()(size_t ip, const Point3& /*point*/,
 bool NoDistanceWeighting::sameAs(const DistanceWeighting& other) const {
     const auto* o = dynamic_cast<const NoDistanceWeighting*>(&other);
     return (o != nullptr);
+}
+
+
+void NoDistanceWeighting::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "no";
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/NoDistanceWeighting.h
+++ b/src/mir/method/knn/distance/NoDistanceWeighting.h
@@ -25,6 +25,7 @@ struct NoDistanceWeighting : DistanceWeighting {
 
 private:
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 };

--- a/src/mir/method/knn/distance/PseudoLaplace.cc
+++ b/src/mir/method/knn/distance/PseudoLaplace.cc
@@ -14,6 +14,8 @@
 
 #include <sstream>
 
+#include "eckit/log/JSON.h"
+
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -102,6 +104,13 @@ void PseudoLaplace::operator()(size_t ip, const Point3& point,
 
 bool PseudoLaplace::sameAs(const DistanceWeighting& other) const {
     return dynamic_cast<const PseudoLaplace*>(&other) != nullptr;
+}
+
+
+void PseudoLaplace::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "pseudo-laplace";
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/distance/PseudoLaplace.h
+++ b/src/mir/method/knn/distance/PseudoLaplace.h
@@ -25,6 +25,7 @@ struct PseudoLaplace : DistanceWeighting {
 
 private:
     bool sameAs(const DistanceWeighting&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 };

--- a/src/mir/method/knn/pick/Distance.cc
+++ b/src/mir/method/knn/pick/Distance.cc
@@ -12,6 +12,7 @@
 
 #include "mir/method/knn/pick/Distance.h"
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -43,6 +44,14 @@ size_t Distance::n() const {
 bool Distance::sameAs(const Pick& other) const {
     const auto* o = dynamic_cast<const Distance*>(&other);
     return (o != nullptr) && eckit::types::is_approximately_equal(distance_, o->distance_);
+}
+
+
+void Distance::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "distance";
+    j << "distance" << distance_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/pick/Distance.h
+++ b/src/mir/method/knn/pick/Distance.h
@@ -25,8 +25,10 @@ struct Distance : Pick {
     bool sameAs(const Pick&) const override;
 
 private:
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
     double distance_;
 };
 

--- a/src/mir/method/knn/pick/DistanceAndNClosest.cc
+++ b/src/mir/method/knn/pick/DistanceAndNClosest.cc
@@ -12,6 +12,7 @@
 
 #include "mir/method/knn/pick/DistanceAndNClosest.h"
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -47,6 +48,15 @@ bool DistanceAndNClosest::sameAs(const Pick& other) const {
     const auto* o = dynamic_cast<const DistanceAndNClosest*>(&other);
     return (o != nullptr) && nClosest_.sameAs(o->nClosest_) &&
            eckit::types::is_approximately_equal(distance_, o->distance_);
+}
+
+
+void DistanceAndNClosest::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "distance-and-nclosest";
+    j << "nclosest" << nClosest_;
+    j << "distance" << distance_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/pick/DistanceAndNClosest.h
+++ b/src/mir/method/knn/pick/DistanceAndNClosest.h
@@ -26,8 +26,10 @@ struct DistanceAndNClosest : Pick {
     bool sameAs(const Pick&) const override;
 
 private:
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
     NClosestOrNearest nClosest_;
     double distance_;
 };

--- a/src/mir/method/knn/pick/DistanceOrNClosest.cc
+++ b/src/mir/method/knn/pick/DistanceOrNClosest.cc
@@ -12,6 +12,7 @@
 
 #include "mir/method/knn/pick/DistanceOrNClosest.h"
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -47,6 +48,15 @@ bool DistanceOrNClosest::sameAs(const Pick& other) const {
     const auto* o = dynamic_cast<const DistanceOrNClosest*>(&other);
     return (o != nullptr) && nClosest_.sameAs(o->nClosest_) &&
            eckit::types::is_approximately_equal(distance_, o->distance_);
+}
+
+
+void DistanceOrNClosest::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "distance-or-nclosest";
+    j << "nclosest" << nClosest_;
+    j << "distance" << distance_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/pick/DistanceOrNClosest.h
+++ b/src/mir/method/knn/pick/DistanceOrNClosest.h
@@ -26,8 +26,10 @@ struct DistanceOrNClosest : Pick {
     bool sameAs(const Pick&) const override;
 
 private:
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
     NClosestOrNearest nClosest_;
     double distance_;
 };

--- a/src/mir/method/knn/pick/LongestElementDiagonalAndNClosest.cc
+++ b/src/mir/method/knn/pick/LongestElementDiagonalAndNClosest.cc
@@ -12,6 +12,7 @@
 
 #include "mir/method/knn/pick/LongestElementDiagonalAndNClosest.h"
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -75,6 +76,15 @@ void LongestElementDiagonalAndNClosest::distance(const repres::Representation& i
     ASSERT(0. < distance_);
 
     distance2_ = distance_ * distance_;
+}
+
+
+void LongestElementDiagonalAndNClosest::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "longest-element-diagonal-and-nclosest";
+    j << "nclosest" << nClosest_;
+    j << "distance" << distance_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/pick/LongestElementDiagonalAndNClosest.h
+++ b/src/mir/method/knn/pick/LongestElementDiagonalAndNClosest.h
@@ -26,8 +26,10 @@ struct LongestElementDiagonalAndNClosest : Pick {
 
 private:
     void distance(const repres::Representation&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
     size_t nClosest_;
     mutable double distance_;
     mutable double distance2_;

--- a/src/mir/method/knn/pick/NClosest.cc
+++ b/src/mir/method/knn/pick/NClosest.cc
@@ -12,6 +12,7 @@
 
 #include "mir/method/knn/pick/NClosest.h"
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 #include "mir/param/MIRParametrisation.h"
@@ -42,6 +43,14 @@ size_t NClosest::n() const {
 bool NClosest::sameAs(const Pick& other) const {
     const auto* o = dynamic_cast<const NClosest*>(&other);
     return (o != nullptr) && nClosest_ == o->nClosest_;
+}
+
+
+void NClosest::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "nclosest";
+    j << "nclosest" << nClosest_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/pick/NClosest.h
+++ b/src/mir/method/knn/pick/NClosest.h
@@ -25,8 +25,10 @@ struct NClosest : Pick {
     bool sameAs(const Pick&) const override;
 
 private:
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+
     size_t nClosest_;
 };
 

--- a/src/mir/method/knn/pick/NClosestOrNearest.cc
+++ b/src/mir/method/knn/pick/NClosestOrNearest.cc
@@ -14,6 +14,7 @@
 
 #include <cmath>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -77,6 +78,15 @@ bool NClosestOrNearest::sameAs(const Pick& other) const {
     const auto* o = dynamic_cast<const NClosestOrNearest*>(&other);
     return (o != nullptr) && nClosest_ == o->nClosest_ &&
            eckit::types::is_approximately_equal(distanceTolerance_, o->distanceTolerance_);
+}
+
+
+void NClosestOrNearest::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "nclosest-or-nearest";
+    j << "nclosest" << nClosest_;
+    j << "distanceTolerance" << distanceTolerance_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/pick/NClosestOrNearest.h
+++ b/src/mir/method/knn/pick/NClosestOrNearest.h
@@ -27,7 +27,9 @@ struct NClosestOrNearest : Pick {
     void hash(eckit::MD5&) const override;
 
 private:
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
+
     size_t nClosest_;
     double distanceTolerance_;
     double distanceTolerance2_;

--- a/src/mir/method/knn/pick/NearestNeighbourWithLowestIndex.cc
+++ b/src/mir/method/knn/pick/NearestNeighbourWithLowestIndex.cc
@@ -15,6 +15,7 @@
 #include <ostream>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -70,6 +71,14 @@ size_t NearestNeighbourWithLowestIndex::n() const {
 bool NearestNeighbourWithLowestIndex::sameAs(const Pick& other) const {
     const auto* o = dynamic_cast<const NearestNeighbourWithLowestIndex*>(&other);
     return (o != nullptr);
+}
+
+
+void NearestNeighbourWithLowestIndex::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "nearest-neighbour-with-lowest-index";
+    j << "nclosest" << nClosest_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/pick/NearestNeighbourWithLowestIndex.h
+++ b/src/mir/method/knn/pick/NearestNeighbourWithLowestIndex.h
@@ -29,6 +29,7 @@ struct NearestNeighbourWithLowestIndex : Pick {
     bool sameAs(const Pick&) const override;
 
 private:
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 

--- a/src/mir/method/knn/pick/Pick.h
+++ b/src/mir/method/knn/pick/Pick.h
@@ -18,8 +18,9 @@
 
 
 namespace eckit {
+class JSON;
 class MD5;
-}
+}  // namespace eckit
 
 namespace mir::repres {
 class Representation;
@@ -36,8 +37,11 @@ public:
     Pick();
     virtual ~Pick();
 
-    Pick(const Pick&)            = delete;
+    Pick(const Pick&) = delete;
+    Pick(Pick&&)      = delete;
+
     Pick& operator=(const Pick&) = delete;
+    Pick& operator=(Pick&&)      = delete;
 
     virtual void pick(const search::PointSearch&, const Point3&, neighbours_t&) const = 0;
     virtual size_t n() const                                                          = 0;
@@ -47,10 +51,16 @@ public:
     virtual void distance(const repres::Representation&) const;
 
 private:
+    virtual void json(eckit::JSON&) const   = 0;
     virtual void print(std::ostream&) const = 0;
 
     friend std::ostream& operator<<(std::ostream& s, const Pick& p) {
         p.print(s);
+        return s;
+    }
+
+    friend eckit::JSON& operator<<(eckit::JSON& s, const Pick& p) {
+        p.json(s);
         return s;
     }
 };

--- a/src/mir/method/knn/pick/Sample.cc
+++ b/src/mir/method/knn/pick/Sample.cc
@@ -14,6 +14,7 @@
 
 #include <cstdlib>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -62,6 +63,15 @@ size_t Sample::n() const {
 bool Sample::sameAs(const Pick& other) const {
     const auto* o = dynamic_cast<const Sample*>(&other);
     return (o != nullptr) && eckit::types::is_approximately_equal(distance_, o->distance_);
+}
+
+
+void Sample::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "sample";
+    j << "nclosest" << nClosest_;
+    j << "distance" << distance_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/pick/Sample.h
+++ b/src/mir/method/knn/pick/Sample.h
@@ -26,7 +26,9 @@ struct Sample : Pick {
     void hash(eckit::MD5&) const override;
 
 private:
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
+
     size_t nClosest_;
     double distance_;
 };

--- a/src/mir/method/knn/pick/SortedSample.cc
+++ b/src/mir/method/knn/pick/SortedSample.cc
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 
@@ -46,6 +47,14 @@ bool SortedSample::sameAs(const Pick& other) const {
 void SortedSample::hash(eckit::MD5& h) const {
     h << "sample-sorted";
     h << sample_;
+}
+
+
+void SortedSample::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "sorted-sample";
+    j << "sample" << sample_;
+    j.endObject();
 }
 
 

--- a/src/mir/method/knn/pick/SortedSample.h
+++ b/src/mir/method/knn/pick/SortedSample.h
@@ -27,7 +27,9 @@ struct SortedSample : Pick {
     void hash(eckit::MD5&) const override;
 
 private:
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
+
     Sample sample_;
 };
 

--- a/src/mir/method/nonlinear/Heaviest.cc
+++ b/src/mir/method/nonlinear/Heaviest.cc
@@ -15,6 +15,7 @@
 #include <ostream>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 
@@ -71,6 +72,13 @@ void Heaviest::hash(eckit::MD5& h) const {
     std::ostringstream s;
     s << *this;
     h.add(s.str());
+}
+
+
+void Heaviest::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "heaviest";
+    j.endObject();
 }
 
 

--- a/src/mir/method/nonlinear/Heaviest.h
+++ b/src/mir/method/nonlinear/Heaviest.h
@@ -25,6 +25,7 @@ private:
     bool treatment(MethodWeighted::Matrix& A, MethodWeighted::WeightMatrix& W, MethodWeighted::Matrix& B,
                    const MIRValuesVector&, const double& missingValue) const override;
     bool sameAs(const NonLinear&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 

--- a/src/mir/method/nonlinear/MissingIfAllMissing.cc
+++ b/src/mir/method/nonlinear/MissingIfAllMissing.cc
@@ -15,6 +15,7 @@
 #include <ostream>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -105,6 +106,13 @@ void MissingIfAllMissing::hash(eckit::MD5& h) const {
     std::ostringstream s;
     s << *this;
     h.add(s.str());
+}
+
+
+void MissingIfAllMissing::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "missing-if-all-missing";
+    j.endObject();
 }
 
 

--- a/src/mir/method/nonlinear/MissingIfAllMissing.h
+++ b/src/mir/method/nonlinear/MissingIfAllMissing.h
@@ -25,6 +25,7 @@ private:
     bool treatment(MethodWeighted::Matrix& A, MethodWeighted::WeightMatrix& W, MethodWeighted::Matrix& B,
                    const MIRValuesVector&, const double& missingValue) const override;
     bool sameAs(const NonLinear&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 

--- a/src/mir/method/nonlinear/MissingIfAnyMissing.cc
+++ b/src/mir/method/nonlinear/MissingIfAnyMissing.cc
@@ -15,6 +15,7 @@
 #include <ostream>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 #include "mir/util/Exceptions.h"
@@ -87,6 +88,13 @@ void MissingIfAnyMissing::hash(eckit::MD5& h) const {
     std::ostringstream s;
     s << *this;
     h.add(s.str());
+}
+
+
+void MissingIfAnyMissing::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "missing-if-any-missing";
+    j.endObject();
 }
 
 

--- a/src/mir/method/nonlinear/MissingIfAnyMissing.h
+++ b/src/mir/method/nonlinear/MissingIfAnyMissing.h
@@ -25,6 +25,7 @@ private:
     bool treatment(MethodWeighted::Matrix& A, MethodWeighted::WeightMatrix& W, MethodWeighted::Matrix& B,
                    const MIRValuesVector&, const double& missingValue) const override;
     bool sameAs(const NonLinear&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 

--- a/src/mir/method/nonlinear/MissingIfHeaviestMissing.cc
+++ b/src/mir/method/nonlinear/MissingIfHeaviestMissing.cc
@@ -15,6 +15,7 @@
 #include <ostream>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -110,6 +111,13 @@ void MissingIfHeaviestMissing::hash(eckit::MD5& h) const {
     std::ostringstream s;
     s << *this;
     h.add(s.str());
+}
+
+
+void MissingIfHeaviestMissing::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "missing-if-heaviest-missing";
+    j.endObject();
 }
 
 

--- a/src/mir/method/nonlinear/MissingIfHeaviestMissing.h
+++ b/src/mir/method/nonlinear/MissingIfHeaviestMissing.h
@@ -25,6 +25,7 @@ private:
     bool treatment(MethodWeighted::Matrix& A, MethodWeighted::WeightMatrix& W, MethodWeighted::Matrix& B,
                    const MIRValuesVector&, const double& missingValue) const override;
     bool sameAs(const NonLinear&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 

--- a/src/mir/method/nonlinear/NoNonLinear.cc
+++ b/src/mir/method/nonlinear/NoNonLinear.cc
@@ -15,6 +15,7 @@
 #include <ostream>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 
@@ -47,6 +48,13 @@ void NoNonLinear::hash(eckit::MD5& h) const {
     std::ostringstream s;
     s << *this;
     h.add(s.str());
+}
+
+
+void NoNonLinear::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "no";
+    j.endObject();
 }
 
 

--- a/src/mir/method/nonlinear/NoNonLinear.h
+++ b/src/mir/method/nonlinear/NoNonLinear.h
@@ -25,6 +25,7 @@ private:
     bool treatment(MethodWeighted::Matrix& A, MethodWeighted::WeightMatrix& W, MethodWeighted::Matrix& B,
                    const MIRValuesVector&, const double& missingValue) const override;
     bool sameAs(const NonLinear&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 

--- a/src/mir/method/nonlinear/NonLinear.h
+++ b/src/mir/method/nonlinear/NonLinear.h
@@ -19,6 +19,7 @@
 
 
 namespace eckit {
+class JSON;
 class MD5;
 namespace linalg {
 class Matrix;
@@ -40,7 +41,7 @@ namespace mir::method::nonlinear {
 
 class NonLinear {
 public:
-    NonLinear(const param::MIRParametrisation&);
+    explicit NonLinear(const param::MIRParametrisation&);
 
     NonLinear(const NonLinear&)      = delete;
     void operator=(const NonLinear&) = delete;
@@ -52,8 +53,8 @@ public:
                            const MIRValuesVector&, const double& missingValue) const = 0;
 
     virtual bool sameAs(const NonLinear&) const = 0;
-
-    virtual void hash(eckit::MD5&) const = 0;
+    virtual void hash(eckit::MD5&) const        = 0;
+    virtual void json(eckit::JSON&) const       = 0;
 
     virtual bool modifiesMatrix(bool fieldHasMissingValues) const = 0;
 
@@ -62,6 +63,11 @@ private:
 
     friend std::ostream& operator<<(std::ostream& s, const NonLinear& p) {
         p.print(s);
+        return s;
+    }
+
+    friend eckit::JSON& operator<<(eckit::JSON& s, const NonLinear& p) {
+        p.json(s);
         return s;
     }
 };

--- a/src/mir/method/nonlinear/SimulatedMissingValue.cc
+++ b/src/mir/method/nonlinear/SimulatedMissingValue.cc
@@ -10,11 +10,12 @@
  */
 
 
-#include "mir/method/nonlinear/SimulateMissingValue.h"
+#include "mir/method/nonlinear/SimulatedMissingValue.h"
 
 #include <ostream>
 #include <sstream>
 
+#include "eckit/log/JSON.h"
 #include "eckit/types/FloatCompare.h"
 #include "eckit/utils/MD5.h"
 
@@ -25,15 +26,15 @@
 namespace mir::method::nonlinear {
 
 
-SimulateMissingValue::SimulateMissingValue(const param::MIRParametrisation& param) : NonLinear(param) {
+SimulatedMissingValue::SimulatedMissingValue(const param::MIRParametrisation& param) : NonLinear(param) {
     param.get("simulated-missing-value", missingValue_ = 9999.);
     param.get("simulated-missing-value-epsilon", epsilon_ = 0.);
 }
 
 
-bool SimulateMissingValue::treatment(MethodWeighted::Matrix& /*A*/, MethodWeighted::WeightMatrix& W,
-                                     MethodWeighted::Matrix& /*B*/, const MIRValuesVector& values,
-                                     const double& /*ignored*/) const {
+bool SimulatedMissingValue::treatment(MethodWeighted::Matrix& /*A*/, MethodWeighted::WeightMatrix& W,
+                                      MethodWeighted::Matrix& /*B*/, const MIRValuesVector& values,
+                                      const double& /*ignored*/) const {
     using eckit::types::is_approximately_equal;
 
     auto missingValue = [this](double value) { return is_approximately_equal(value, missingValue_, epsilon_); };
@@ -104,26 +105,35 @@ bool SimulateMissingValue::treatment(MethodWeighted::Matrix& /*A*/, MethodWeight
 }
 
 
-bool SimulateMissingValue::sameAs(const NonLinear& other) const {
-    const auto* o = dynamic_cast<const SimulateMissingValue*>(&other);
+bool SimulatedMissingValue::sameAs(const NonLinear& other) const {
+    const auto* o = dynamic_cast<const SimulatedMissingValue*>(&other);
     return (o != nullptr) && eckit::types::is_approximately_equal(missingValue_, o->missingValue_) &&
            eckit::types::is_approximately_equal(epsilon_, o->epsilon_);
 }
 
 
-void SimulateMissingValue::print(std::ostream& out) const {
-    out << "SimulateMissingValue[missingValue=" << missingValue_ << ",epsilon=" << epsilon_ << "]";
+void SimulatedMissingValue::print(std::ostream& out) const {
+    out << "SimulatedMissingValue[missingValue=" << missingValue_ << ",epsilon=" << epsilon_ << "]";
 }
 
 
-void SimulateMissingValue::hash(eckit::MD5& h) const {
+void SimulatedMissingValue::hash(eckit::MD5& h) const {
     std::ostringstream s;
     s << *this;
     h.add(s.str());
 }
 
 
-static const NonLinearBuilder<SimulateMissingValue> __nonlinear("simulated-missing-value");
+void SimulatedMissingValue::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "simulated-missing-value";
+    j << "missingValue" << missingValue_;
+    j << "epsilon" << epsilon_;
+    j.endObject();
+}
+
+
+static const NonLinearBuilder<SimulatedMissingValue> __nonlinear("simulated-missing-value");
 
 
 }  // namespace mir::method::nonlinear

--- a/src/mir/method/nonlinear/SimulatedMissingValue.h
+++ b/src/mir/method/nonlinear/SimulatedMissingValue.h
@@ -18,13 +18,14 @@
 namespace mir::method::nonlinear {
 
 
-struct SimulateMissingValue : NonLinear {
-    SimulateMissingValue(const param::MIRParametrisation&);
+struct SimulatedMissingValue : NonLinear {
+    SimulatedMissingValue(const param::MIRParametrisation&);
 
 private:
     bool treatment(MethodWeighted::Matrix& A, MethodWeighted::WeightMatrix& W, MethodWeighted::Matrix& B,
                    const MIRValuesVector&, const double&) const override;
     bool sameAs(const NonLinear&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
 

--- a/src/mir/method/solver/Multiply.cc
+++ b/src/mir/method/solver/Multiply.cc
@@ -17,6 +17,7 @@
 
 #include "eckit/linalg/LinearAlgebraSparse.h"
 #include "eckit/linalg/Vector.h"
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 #include "mir/util/Exceptions.h"
@@ -63,6 +64,13 @@ void Multiply::hash(eckit::MD5& h) const {
     std::ostringstream s;
     s << *this;
     h.add(s.str());
+}
+
+
+void Multiply::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "multiply";
+    j.endObject();
 }
 
 

--- a/src/mir/method/solver/Multiply.h
+++ b/src/mir/method/solver/Multiply.h
@@ -34,6 +34,7 @@ private:
     bool sameAs(const Solver&) const override;
     void print(std::ostream&) const override;
     void hash(eckit::MD5&) const override;
+    void json(eckit::JSON&) const override;
 
     const eckit::linalg::LinearAlgebraSparse& backend_;
 };

--- a/src/mir/method/solver/Solver.h
+++ b/src/mir/method/solver/Solver.h
@@ -19,8 +19,9 @@
 
 
 namespace eckit {
+class JSON;
 class MD5;
-}
+}  // namespace eckit
 
 namespace mir::param {
 class MIRParametrisation;
@@ -33,25 +34,33 @@ namespace mir::method::solver {
 /// Solve linear system (B = W A)
 class Solver {
 public:
-    Solver(const param::MIRParametrisation&) {}
+    explicit Solver(const param::MIRParametrisation&) {}
 
-    Solver(const Solver&)         = delete;
-    void operator=(const Solver&) = delete;
+    Solver(const Solver&) = delete;
+    Solver(Solver&&)      = delete;
 
     virtual ~Solver() = default;
+
+    void operator=(const Solver&) = delete;
+    void operator=(Solver&&)      = delete;
 
     virtual void solve(const MethodWeighted::Matrix& A, const MethodWeighted::WeightMatrix& W,
                        MethodWeighted::Matrix& B, const double& missingValue) const = 0;
 
     virtual bool sameAs(const Solver&) const = 0;
-
-    virtual void hash(eckit::MD5&) const = 0;
+    virtual void hash(eckit::MD5&) const     = 0;
+    virtual void json(eckit::JSON&) const    = 0;
 
 private:
     virtual void print(std::ostream&) const = 0;
 
     friend std::ostream& operator<<(std::ostream& s, const Solver& p) {
         p.print(s);
+        return s;
+    }
+
+    friend eckit::JSON& operator<<(eckit::JSON& s, const Solver& p) {
+        p.json(s);
         return s;
     }
 };

--- a/src/mir/method/solver/Statistics.cc
+++ b/src/mir/method/solver/Statistics.cc
@@ -72,4 +72,12 @@ void Statistics::hash(eckit::MD5& h) const {
 }
 
 
+void Statistics::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "statistics";
+    j << "statistics" << *stats_;
+    j.endObject();
+}
+
+
 }  // namespace mir::method::solver

--- a/src/mir/method/solver/Statistics.h
+++ b/src/mir/method/solver/Statistics.h
@@ -14,6 +14,8 @@
 
 #include <memory>
 
+#include "eckit/log/JSON.h"
+
 #include "mir/method/solver/Solver.h"
 
 
@@ -37,10 +39,9 @@ struct Statistics final : solver::Solver {
 
 private:
     bool sameAs(const Solver&) const override;
-
     void print(std::ostream&) const override;
-
     void hash(eckit::MD5&) const override;
+    void json(eckit::JSON&) const override;
 
     std::unique_ptr<stats::Field> stats_;
 };

--- a/src/mir/method/structured/StructuredBilinearLatLon.cc
+++ b/src/mir/method/structured/StructuredBilinearLatLon.cc
@@ -34,9 +34,6 @@ static const MethodBuilder<StructuredBilinearLatLon> __method("structured-biline
 StructuredBilinearLatLon::StructuredBilinearLatLon(const param::MIRParametrisation& param) : StructuredMethod(param) {}
 
 
-StructuredBilinearLatLon::~StructuredBilinearLatLon() = default;
-
-
 bool StructuredBilinearLatLon::sameAs(const Method& other) const {
     const auto* o = dynamic_cast<const StructuredBilinearLatLon*>(&other);
     return (o != nullptr) && StructuredMethod::sameAs(other);
@@ -285,9 +282,17 @@ void StructuredBilinearLatLon::hash(eckit::MD5& md5) const {
 }
 
 
+void StructuredBilinearLatLon::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "structured-bilinear-latlon";
+    MethodWeighted::json(j);
+    j.endObject();
+}
+
+
 void StructuredBilinearLatLon::print(std::ostream& out) const {
     out << "StructuredBilinearLatLon[";
-    StructuredMethod::print(out);
+    MethodWeighted::print(out);
     out << "]";
 }
 

--- a/src/mir/method/structured/StructuredBilinearLatLon.h
+++ b/src/mir/method/structured/StructuredBilinearLatLon.h
@@ -18,21 +18,17 @@
 namespace mir::method::structured {
 
 
-class StructuredBilinearLatLon : public StructuredMethod {
-public:
-    StructuredBilinearLatLon(const param::MIRParametrisation&);
-    ~StructuredBilinearLatLon() override;
+struct StructuredBilinearLatLon final : StructuredMethod {
+    explicit StructuredBilinearLatLon(const param::MIRParametrisation&);
 
 private:
     void assembleStructuredInput(WeightMatrix&, const repres::Representation& in,
                                  const repres::Representation& out) const override;
 
     const char* name() const override;
-
     void hash(eckit::MD5&) const override;
-
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
-
     bool sameAs(const Method&) const override;
 };
 

--- a/src/mir/method/structured/StructuredLinear3D.cc
+++ b/src/mir/method/structured/StructuredLinear3D.cc
@@ -40,9 +40,6 @@ static const MethodBuilder<StructuredLinear3D> __method("structured-linear-3d");
 StructuredLinear3D::StructuredLinear3D(const param::MIRParametrisation& param) : StructuredMethod(param) {}
 
 
-StructuredLinear3D::~StructuredLinear3D() = default;
-
-
 bool StructuredLinear3D::sameAs(const Method& other) const {
     const auto* o = dynamic_cast<const StructuredLinear3D*>(&other);
     return (o != nullptr) && StructuredMethod::sameAs(other);
@@ -216,6 +213,14 @@ const char* StructuredLinear3D::name() const {
 
 void StructuredLinear3D::hash(eckit::MD5& md5) const {
     StructuredMethod::hash(md5);
+}
+
+
+void StructuredLinear3D::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "structured-linear-3d";
+    MethodWeighted::json(j);
+    j.endObject();
 }
 
 

--- a/src/mir/method/structured/StructuredLinear3D.h
+++ b/src/mir/method/structured/StructuredLinear3D.h
@@ -18,21 +18,17 @@
 namespace mir::method::structured {
 
 
-class StructuredLinear3D : public StructuredMethod {
-public:
-    StructuredLinear3D(const param::MIRParametrisation&);
-    ~StructuredLinear3D() override;
+struct StructuredLinear3D final : StructuredMethod {
+    explicit StructuredLinear3D(const param::MIRParametrisation&);
 
 private:
     void assembleStructuredInput(WeightMatrix&, const repres::Representation& in,
                                  const repres::Representation& out) const override;
 
     const char* name() const override;
-
     void hash(eckit::MD5&) const override;
-
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
-
     bool sameAs(const Method&) const override;
 };
 

--- a/src/mir/method/structured/StructuredMethod.cc
+++ b/src/mir/method/structured/StructuredMethod.cc
@@ -14,6 +14,8 @@
 
 #include <memory>
 
+#include "eckit/log/JSON.h"
+
 #include "mir/repres/Iterator.h"
 #include "mir/repres/Representation.h"
 #include "mir/util/Exceptions.h"
@@ -174,10 +176,5 @@ void StructuredMethod::assemble(util::MIRStatistics& /*unused*/, WeightMatrix& W
     Log::debug() << "StructuredMethod::assemble." << std::endl;
 }
 
-void StructuredMethod::print(std::ostream& out) const {
-    out << "StructuredMethod[";
-    MethodWeighted::print(out);
-    out << "]";
-}
 
 }  // namespace mir::method::structured

--- a/src/mir/method/structured/StructuredMethod.h
+++ b/src/mir/method/structured/StructuredMethod.h
@@ -62,8 +62,6 @@ protected:
 
     bool sameAs(const Method&) const override = 0;
 
-    void print(std::ostream&) const override;
-
 private:
     void assemble(util::MIRStatistics&, WeightMatrix&, const repres::Representation& in,
                   const repres::Representation& out) const override;

--- a/src/mir/method/voronoi/VoronoiMethod.cc
+++ b/src/mir/method/voronoi/VoronoiMethod.cc
@@ -18,6 +18,7 @@
 #include <sstream>
 #include <utility>
 
+#include "eckit/log/JSON.h"
 #include "eckit/utils/MD5.h"
 
 #include "mir/repres/Iterator.h"
@@ -150,6 +151,14 @@ void VoronoiMethod::hash(eckit::MD5& md5) const {
     std::ostringstream str;
     print(str);
     md5.add(str.str());
+}
+
+
+void VoronoiMethod::json(eckit::JSON& j) const {
+    j.startObject();
+    j << "type" << "voronoi-method";
+    MethodWeighted::json(j);
+    j.endObject();
 }
 
 

--- a/src/mir/method/voronoi/VoronoiMethod.h
+++ b/src/mir/method/voronoi/VoronoiMethod.h
@@ -21,81 +21,19 @@ namespace mir::method::voronoi {
 
 class VoronoiMethod : public MethodWeighted {
 public:
-    // -- Types
-    // None
-
-    // -- Exceptions
-    // None
-
-    // -- Constructors
-
-    explicit VoronoiMethod(const param::MIRParametrisation& param);
-
-    // -- Destructor
-
-    virtual ~VoronoiMethod() override = default;
-
-    // -- Convertors
-    // None
-
-    // -- Operators
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-protected:
-    // -- Members
-    // None
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-    // None
-
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
+    explicit VoronoiMethod(const param::MIRParametrisation&);
 
 private:
-    // -- Members
-
-    knn::pick::NClosestOrNearest pick_;
-
-    // -- Methods
-    // None
-
-    // -- Overridden methods
-
-    // From MethodWeighted
     void hash(eckit::MD5&) const override;
     void assemble(util::MIRStatistics&, WeightMatrix&, const repres::Representation& in,
                   const repres::Representation& out) const override;
     bool sameAs(const Method&) const override;
+    void json(eckit::JSON&) const override;
     void print(std::ostream&) const override;
     bool validateMatrixWeights() const override;
     const char* name() const override;
 
-    // -- Class members
-    // None
-
-    // -- Class methods
-    // None
-
-    // -- Friends
-    // None
+    knn::pick::NClosestOrNearest pick_;
 };
 
 

--- a/src/mir/method/voronoi/VoronoiStatistics.h
+++ b/src/mir/method/voronoi/VoronoiStatistics.h
@@ -20,8 +20,6 @@ namespace mir::method::voronoi {
 
 struct VoronoiStatistics final : VoronoiMethod {
     explicit VoronoiStatistics(const param::MIRParametrisation&);
-    VoronoiStatistics(const VoronoiStatistics&) = delete;
-    void operator=(const VoronoiStatistics&)    = delete;
 };
 
 

--- a/src/mir/stats/Field.cc
+++ b/src/mir/stats/Field.cc
@@ -12,8 +12,11 @@
 
 #include "mir/stats/Field.h"
 
+#include <cmath>
 #include <map>
 #include <ostream>
+
+#include "eckit/log/JSON.h"
 
 #include "mir/util/Exceptions.h"
 #include "mir/util/Log.h"
@@ -33,6 +36,16 @@ static void init() {
 
 
 Field::Field(const param::MIRParametrisation& /*unused*/) {}
+
+
+void Field::json_tv(eckit::JSON& j, const std::string& type, double value) {
+    j.startObject();
+    j << "type" << type;
+    if (!std::isnan(value)) {
+        j << "value" << value;
+    }
+    j.endObject();
+}
 
 
 Field::~Field() = default;

--- a/src/mir/stats/Field.h
+++ b/src/mir/stats/Field.h
@@ -16,6 +16,10 @@
 #include <string>
 
 
+namespace eckit {
+class JSON;
+}
+
 namespace mir::param {
 class MIRParametrisation;
 }  // namespace mir::param
@@ -31,8 +35,10 @@ public:
 
     // -- Constructors
 
-    Field(const param::MIRParametrisation&);
+    explicit Field(const param::MIRParametrisation&);
+
     Field(const Field&) = delete;
+    Field(Field&&)      = delete;
 
     // -- Destructor
 
@@ -44,6 +50,7 @@ public:
     // -- Operators
 
     void operator=(const Field&) = delete;
+    void operator=(Field&&)      = delete;
 
     // -- Methods
 
@@ -66,7 +73,10 @@ protected:
 
     // -- Methods
 
+    virtual void json(eckit::JSON&) const   = 0;
     virtual void print(std::ostream&) const = 0;
+
+    static void json_tv(eckit::JSON&, const std::string& type, double value);
 
     // -- Overridden methods
     // None
@@ -97,6 +107,11 @@ private:
 
     friend std::ostream& operator<<(std::ostream& out, const Field& r) {
         r.print(out);
+        return out;
+    }
+
+    friend eckit::JSON& operator<<(eckit::JSON& out, const Field& r) {
+        r.json(out);
         return out;
     }
 };

--- a/src/mir/stats/field/CentralMomentStats.cc
+++ b/src/mir/stats/field/CentralMomentStats.cc
@@ -13,6 +13,8 @@
 
 #include <ostream>
 
+#include "eckit/log/JSON.h"
+
 #include "mir/stats/Field.h"
 #include "mir/stats/detail/CentralMomentsT.h"
 
@@ -23,6 +25,7 @@ namespace mir::stats::field {
 struct Mean final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
     using CentralMomentStatsT::CentralMomentStatsT;
     double value() const override { return mean(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "mean", value()); }
     void print(std::ostream& out) const override { out << "Mean[]"; }
 };
 
@@ -30,6 +33,7 @@ struct Mean final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
 struct Variance final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
     using CentralMomentStatsT::CentralMomentStatsT;
     double value() const override { return variance(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "variance", value()); }
     void print(std::ostream& out) const override { out << "Variance[]"; }
 };
 
@@ -37,6 +41,7 @@ struct Variance final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
 struct Skewness final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
     using CentralMomentStatsT::CentralMomentStatsT;
     double value() const override { return skewness(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "skewness", value()); }
     void print(std::ostream& out) const override { out << "Skewness[]"; }
 };
 
@@ -44,6 +49,7 @@ struct Skewness final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
 struct Kurtosis final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
     using CentralMomentStatsT::CentralMomentStatsT;
     double value() const override { return kurtosis(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "kurtosis", value()); }
     void print(std::ostream& out) const override { out << "Kurtosis[]"; }
 };
 
@@ -51,13 +57,15 @@ struct Kurtosis final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
 struct StandardDeviation final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
     using CentralMomentStatsT::CentralMomentStatsT;
     double value() const override { return standardDeviation(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "stddev", value()); }
     void print(std::ostream& out) const override { out << "StandardDeviation[]"; }
 };
 
 
 struct Sum final : CentralMomentStatsT<detail::CentralMomentsT<double>> {
     using CentralMomentStatsT::CentralMomentStatsT;
-    double value() const override { return mean() * double(Counter::count()); }
+    double value() const override { return mean() * static_cast<double>(Counter::count()); }
+    void json(eckit::JSON& j) const override { json_tv(j, "sum", value()); }
     void print(std::ostream& out) const override { out << "Sum[]"; }
 };
 

--- a/src/mir/stats/field/CentralMomentStats.h
+++ b/src/mir/stats/field/CentralMomentStats.h
@@ -25,7 +25,9 @@ struct CentralMomentStatsT : detail::Counter, Field, STATS {
     CentralMomentStatsT(const param::MIRParametrisation& param) : Counter(param), Field(param) {}
     ~CentralMomentStatsT() override = default;
 
-    virtual double value() const override = 0;
+    double value() const override            = 0;
+    void json(eckit::JSON&) const override   = 0;
+    void print(std::ostream&) const override = 0;
 
     void count(const double& value) override {
         if (Counter::count(value)) {

--- a/src/mir/stats/field/CounterStats.cc
+++ b/src/mir/stats/field/CounterStats.cc
@@ -14,6 +14,8 @@
 
 #include <ostream>
 
+#include "eckit/log/JSON.h"
+
 
 namespace mir::stats::field {
 
@@ -21,6 +23,7 @@ namespace mir::stats::field {
 struct Count final : CounterStats {
     using CounterStats::CounterStats;
     double value() const override { return double(Counter::count() - Counter::missing()); }
+    void json(eckit::JSON& j) const override { json_tv(j, "count", value()); }
     void print(std::ostream& out) const override { out << "Count[" << value() << "]"; }
 };
 
@@ -28,6 +31,7 @@ struct Count final : CounterStats {
 struct CountAboveUpperLimit final : CounterStats {
     using CounterStats::CounterStats;
     double value() const override { return double(countAboveUpperLimit()); }
+    void json(eckit::JSON& j) const override { json_tv(j, "count-above-upper-limit", value()); }
     void print(std::ostream& out) const override { out << "CountAboveUpperLimit[" << value() << "]"; }
 };
 
@@ -35,6 +39,7 @@ struct CountAboveUpperLimit final : CounterStats {
 struct CountBelowLowerLimit final : CounterStats {
     using CounterStats::CounterStats;
     double value() const override { return double(countBelowLowerLimit()); }
+    void json(eckit::JSON& j) const override { json_tv(j, "count-below-upper-limit", value()); }
     void print(std::ostream& out) const override { out << "CountBelowLowerLimit[" << value() << "]"; }
 };
 
@@ -42,6 +47,7 @@ struct CountBelowLowerLimit final : CounterStats {
 struct Maximum final : CounterStats {
     using CounterStats::CounterStats;
     double value() const override { return max(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "maximum", value()); }
     void print(std::ostream& out) const override { out << "Maximum[" << value() << "]"; }
 };
 
@@ -49,6 +55,7 @@ struct Maximum final : CounterStats {
 struct Minimum final : CounterStats {
     using CounterStats::CounterStats;
     double value() const override { return min(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "minimum", value()); }
     void print(std::ostream& out) const override { out << "Minimum[" << value() << "]"; }
 };
 

--- a/src/mir/stats/field/CounterStats.h
+++ b/src/mir/stats/field/CounterStats.h
@@ -23,8 +23,9 @@ namespace mir::stats::field {
 struct CounterStats : detail::Counter, Field {
     CounterStats(const param::MIRParametrisation& param) : Counter(param), Field(param) {}
 
-    virtual double value() const override            = 0;
-    virtual void print(std::ostream&) const override = 0;
+    double value() const override            = 0;
+    void json(eckit::JSON&) const override   = 0;
+    void print(std::ostream&) const override = 0;
 
     void count(const double& value) override { Counter::count(value); }
     void reset(double missingValue, bool hasMissing) override { Counter::reset(missingValue, hasMissing); }

--- a/src/mir/stats/field/ModeStats.cc
+++ b/src/mir/stats/field/ModeStats.cc
@@ -14,6 +14,8 @@
 
 #include <ostream>
 
+#include "eckit/log/JSON.h"
+
 #include "mir/stats/detail/ModeT.h"
 
 
@@ -23,6 +25,7 @@ namespace mir::stats::field {
 struct ModeReal final : ModeStatsT<detail::ModeReal> {
     using ModeStatsT::ModeStatsT;
     double value() const override { return mode(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "mode-real", value()); }
     void print(std::ostream& out) const override { out << "ModeReal[" << value() << "]"; }
 };
 
@@ -30,6 +33,7 @@ struct ModeReal final : ModeStatsT<detail::ModeReal> {
 struct ModeIntegral final : ModeStatsT<detail::ModeIntegral> {
     using ModeStatsT::ModeStatsT;
     double value() const override { return mode(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "mode-integral", value()); }
     void print(std::ostream& out) const override { out << "ModeIntegral[" << value() << "]"; }
 };
 
@@ -37,6 +41,7 @@ struct ModeIntegral final : ModeStatsT<detail::ModeIntegral> {
 struct ModeBoolean final : ModeStatsT<detail::ModeBoolean> {
     using ModeStatsT::ModeStatsT;
     double value() const override { return mode(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "mode-boolean", value()); }
     void print(std::ostream& out) const override { out << "ModeBoolean[" << value() << "]"; }
 };
 
@@ -44,6 +49,7 @@ struct ModeBoolean final : ModeStatsT<detail::ModeBoolean> {
 struct MedianIntegral final : ModeStatsT<detail::MedianIntegral> {
     using ModeStatsT::ModeStatsT;
     double value() const override { return median(); }
+    void json(eckit::JSON& j) const override { json_tv(j, "median-integral", value()); }
     void print(std::ostream& out) const override { out << "MedianIntegral[" << value() << "]"; }
 };
 

--- a/src/mir/stats/field/ModeStats.h
+++ b/src/mir/stats/field/ModeStats.h
@@ -24,8 +24,9 @@ template <typename STATS>
 struct ModeStatsT : detail::Counter, Field, STATS {
     ModeStatsT(const param::MIRParametrisation& param) : Counter(param), Field(param), STATS(param) {}
 
-    virtual double value() const override            = 0;
-    virtual void print(std::ostream&) const override = 0;
+    double value() const override            = 0;
+    void json(eckit::JSON&) const override   = 0;
+    void print(std::ostream&) const override = 0;
 
     void count(const double& value) override {
         if (Counter::count(value)) {


### PR DESCRIPTION
This branch is part of the effort to integrate/improve earthkit-regrid, by also generating an interpolation identifier ("interpolationspec") together with input/output "gridspec"s. It came from the necessity that not all grids might suport all interpolation methods, and there is the obvious case that one can then use multiple methods for the same input/output combination. This guarantees that one can find one of many possible matrices relating input to output, and can be used as a unique identifier for the interpolation proper.

This change consists of a fairly comprehensive implemention of generating JSON's for all components in MIR's interpolation methods, which will ideally replace the "print"-like methods (eventually). It might be of interest to additionaly tag the version/date (or similar), similar to what is necessary to do in production for the cache files.

This is linked to internal issue
https://jira.ecmwf.int/browse/MIR-646