### PR TITLE
MIR-670 SharedMemoryLoader: send logs to debug channel

### DIFF
--- a/src/mir/caching/legendre/SharedMemoryLoader.cc
+++ b/src/mir/caching/legendre/SharedMemoryLoader.cc
@@ -124,7 +124,7 @@ SharedMemoryLoader::SharedMemoryLoader(const param::MIRParametrisation& parametr
     std::ostringstream msg("SharedMemoryLoader: ");
 
     msg << "path='" << real << "', hostname='" << eckit::Main::hostname() << "'";
-    Log::info() << msg.str() << std::endl;
+    Log::debug() << msg.str() << std::endl;
 
     if (real.asString().size() >= INFO_PATH - 1) {
         Log::warning() << msg.str() << ", path name too long, maximum=" << INFO_PATH;

--- a/src/mir/caching/matrix/SharedMemoryLoader.cc
+++ b/src/mir/caching/matrix/SharedMemoryLoader.cc
@@ -121,7 +121,7 @@ SharedMemoryLoader::SharedMemoryLoader(const std::string& name, const eckit::Pat
     std::ostringstream msg("SharedMemoryLoader: ");
 
     msg << "path='" << real << "', hostname='" << eckit::Main::hostname() << "'";
-    Log::info() << msg.str() << std::endl;
+    Log::debug() << msg.str() << std::endl;
 
     if (real.asString().size() >= INFO_PATH - 1) {
         Log::warning() << msg.str() << ", path name too long, maximum=" << INFO_PATH;


### PR DESCRIPTION
Use Log::debug instead of Log::info to output the shared memory loader logs.