### PR TITLE
Python Wrapper: add Atlas

### DIFF
--- a/python_wrapper/buildconfig
+++ b/python_wrapper/buildconfig
@@ -11,6 +11,6 @@
 # TODO we duplicate information -- pyproject.toml's `name` and `packages` are derivable from $NAME and must stay consistent
 
 NAME="mir"
-CMAKE_PARAMS="-Deckit_ROOT=/tmp/mir/prereqs/eckitlib -Deccodes_ROOT=/tmp/mir/prereqs/eccodeslib -Datlas_ROOT=/tmp/mir/prereqs/atlaslib-ecmwf"
+CMAKE_PARAMS="-Deckit_ROOT=/tmp/mir/prereqs/eckitlib -Deccodes_ROOT=/tmp/mir/prereqs/eccodeslib -Datlas_ROOT=/tmp/mir/prereqs/atlaslib-ecmwf -DENABLE_ECKIT_GEO=1"
 PYPROJECT_DIR="python_wrapper"
 DEPENDENCIES='["eccodeslib", "eckitlib", "atlaslib-ecmwf"]'


### PR DESCRIPTION
This will make the python wrapper wheel with Mir depend on and utilize Atlas

This depends on https://github.com/ecmwf/atlas/pull/257 being merged, and additionally I'll need to put there the atlas stripping. I've already tested locally and it seems not to cause any problem in this case. *Edit*: merged already

Also, I believe TESSELATION was asked for in the Atlas build -- that includes me building and bundling Qhull external library into atlas, that will also take some time. *Edit*: bundled already

Lastly, the linux wheel is iirc non functional now because of Orca grids and Lz4 -- cf https://github.com/ecmwf/eckit/pull/173/files. But that does not necessarily prevent this being merged

FYI @pmaciel @iainrussell 