### PR TITLE
Use new name for atlas structured interpolation method (see ecmwf/atlas#296)

### DIFF
--- a/src/mir/method/ProxyMethod.cc
+++ b/src/mir/method/ProxyMethod.cc
@@ -29,18 +29,18 @@ namespace mir::method {
 
 
 struct StructuredBicubic final : public ProxyMethod {
-    explicit StructuredBicubic(const param::MIRParametrisation& param) : ProxyMethod(param, "structured-bicubic") {}
+    explicit StructuredBicubic(const param::MIRParametrisation& param) : ProxyMethod(param, "structured-cubic") {}
 };
 
 
 struct StructuredBilinear final : public ProxyMethod {
-    explicit StructuredBilinear(const param::MIRParametrisation& param) : ProxyMethod(param, "structured-bilinear") {}
+    explicit StructuredBilinear(const param::MIRParametrisation& param) : ProxyMethod(param, "structured-linear") {}
 };
 
 
 struct StructuredBiquasicubic final : public ProxyMethod {
     explicit StructuredBiquasicubic(const param::MIRParametrisation& param) :
-        ProxyMethod(param, "structured-biquasicubic") {}
+        ProxyMethod(param, "structured-quasicubic") {}
 };
 
 


### PR DESCRIPTION
Once ecmwf/atlas#296 is merged, this PR can be merged to avoid deprecation warnings.
Until then, deprecation warnings can also be disabled using environment variable
```ATLAS_DEPRECATION_WARNINGS=0```