### PR TITLE
Fix test that requires tesselation

### DIFF
--- a/tests/unit/gridspec.cc
+++ b/tests/unit/gridspec.cc
@@ -19,6 +19,7 @@
 #include "eckit/testing/Test.h"
 
 #include "mir/api/MIRJob.h"
+#include "mir/api/mir_config.h"
 #include "mir/input/MIRInput.h"
 #include "mir/input/RawInput.h"
 #include "mir/output/EmptyOutput.h"
@@ -38,15 +39,17 @@ CASE("GridSpec input/output") {
         size_t size;
     };
 
-    const std::vector<test_t> tests{
+    std::vector<test_t> tests{
         test_t{"{grid: 10/10}", "{\"grid\":[10,10]}", 684},
         {"{grid: [20, 10]}", "{\"grid\":[20,10]}", 342},
         {"{grid: o8}", "{\"grid\":\"O8\"}", 544},
-        {"{grid: h2n}", "{\"grid\":\"H2\",\"order\":\"nested\"}", 48},
         {"{grid: h2_ring}", "{\"grid\":\"H2\"}", 48},
 
     };
 
+    if (MIR_HAVE_TESSELATION) {
+        tests.push_back(test_t{"{grid: h2n}", "{\"grid\":\"H2\",\"order\":\"nested\"}", 48});
+    }
 
     SECTION("GridSpec canonical") {
         for (const auto& test : tests) {


### PR DESCRIPTION
### Description
Fixes the failing test on platforms that do not have qhull installed. We will install qhull on the platforms that have a recent version available, but there will still be some that do not, so we need to cater for it.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 