### PR TITLE
fix tests 

### DIFF
--- a/tests/assertions/CMakeLists.txt
+++ b/tests/assertions/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_program(MARS_SCRIPT NAMES mars false)
+find_program(MARS_SCRIPT NAMES mars)
 
 ecbuild_configure_file(mir-test.sh.in mir-test.sh @ONLY)
 
@@ -51,6 +51,8 @@ if(NOT atlas_HAVE_TESSELATION)
             MIR-647.001.test)
         get_filename_component(_t "${_r}" ABSOLUTE)
         target_from_path("${_t}" target)
-        set_tests_properties(${target} PROPERTIES WILL_FAIL TRUE)
+        if(${target})
+            set_tests_properties(${target} PROPERTIES WILL_FAIL TRUE)
+        endif()
     endforeach()
 endif()

--- a/tests/plans/CMakeLists.txt
+++ b/tests/plans/CMakeLists.txt
@@ -1,5 +1,5 @@
-find_program(DIFF_TOOL NAMES "diff" "cmp" "false")
-find_program(MARS_SCRIPT NAMES "mars" "false")
+find_program(DIFF_TOOL NAMES "diff" "cmp")
+find_program(MARS_SCRIPT NAMES "mars")
 
 ecbuild_configure_file(mir-test.sh.in mir-test.sh @ONLY)
 


### PR DESCRIPTION
### Description

Resolves the issue on some systems, which has '.../bin/false': `MARS_SCRIPT` var is wrongly assigned to `/usr/bin/false`

also fixes issue when target for `MIR-647.001.test` is missing

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 