### PR TITLE
[python] fix eckit version for mir

### DIFF
--- a/python/mir/setup.py
+++ b/python/mir/setup.py
@@ -6,9 +6,10 @@ import sys
 
 with open('VERSION', 'r') as fVersion:
     version = fVersion.readlines()[0].strip()
+
 install_requires = [
     f"mirlib=={version}",
-    f"eckit=={version}",
+    "eckit", # NOTE we don't pin here, because mirlib is exactly pinned, which in turn exactly pins eckitlib, which in turn constraints eckit
     "findlibs",
     "numpy>=2.0,<3.0", # NOTE may need tighter range in case of ABI issues. Dont forget to keep in sync with pre-compile.sh (or cmake files if numpy install refactored)
     "scipy",


### PR DESCRIPTION
Needed one extra fix, I put there wrong version of eckit in the deps

https://github.com/ecmwf/python-develop-bundle/actions/runs/27274546949 -- a successful build for all platforms

verified with
```
$ uv pip install 'pyyaml==3.11' setuptools # those are required by mir but are not on test pypi
$ uv pip install --prerelease allow -i https://test.pypi.org/simple/ mir-python==1.28.3.dev98
$ python
>>> import mir
>>>
```
(and unlike all previous attempts, this does not crash or complain)